### PR TITLE
PoC: Make sure the new window replaces the current

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,7 @@
 use std::env::args;
 use std::process::Command;
 use std::process::exit;
-use std::thread::sleep;
-use std::time::Duration;
-use swayipc::{Connection, Error};
+use swayipc::{Connection, Error, EventType};
 
 const USAGE: &str = r#"
 A window swallower for sway
@@ -69,9 +67,10 @@ fn hide(args: Vec<String>) -> Result<(), swayipc::Error> {
     // Run command
     let mut child = child_process.spawn().map_err(|err| Error::from_boxed_compat(Box::new(err)))?;
 
-    // FIXME: Here we need to wait for the new window to have appeared.
-    // This waits 1000s, but that's a real hack. I've no idea how to wait properly.
-    sleep(Duration::from_millis(1000));
+    for _ in Connection::new()?.subscribe(&[EventType::Window])? {
+        // FIXME: It's still possible for this window to be entirely unrelated.
+        break;
+    }
 
     // Focus our marked window and hide it.
     con.run_command(format!("[con_mark=\"{}\"] focus; move scratchpad", mark))?;


### PR DESCRIPTION
This is not at all ready to be merged, but is an experiment trying to
implement #1.

By converting the original window into a split, the newly-created window
is added to that split (which guarantees that they're adjacent). Since
the original window is then hidden, the new window effectively takes its
place.

This has a few caveats:

- There's a "wait 1s" hardcoded there:
  - If the new window is faster, this is weird and glitchy.
  - If the new window is slower, this doesn't work.
- When the new window _exits_, the swallowed window won't always take
  its place: it'll be placed relative to the last-focused window, and
  I can't think of any way around this other than continuously
  monitoring the tree to find our right position.

The timeout can we worked around by waiting for _any_ window to appear,
and assuming the first new window to spawn is the one we're creating.
This might be flaky, but I suspect it'd work 90% of the time.

An alternative implementation could also be using a new stacked/tabbed
layout, where the new window is a second in that container. If sway
allowed us to hide the stack/tab bar on that container, we'd be 100%
covered.