### PR TITLE
Remove leftover intermediate container

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -90,8 +90,8 @@ fn hide(args: Vec<String>, tabbed: bool) -> Result<(), swayipc::Error> {
 
         // Focus our marked window and hide it.
         con.run_command(format!("[pid={}] focus; move scratchpad", pid))?;
+        con.run_command("split none")?;
     }
-    con.run_command("split none")?;
 
     // Wait for command to exit
     let status = child

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,6 +91,7 @@ fn hide(args: Vec<String>, tabbed: bool) -> Result<(), swayipc::Error> {
         // Focus our marked window and hide it.
         con.run_command(format!("[pid={}] focus; move scratchpad", pid))?;
     }
+    con.run_command("split none")?;
 
     // Wait for command to exit
     let status = child


### PR DESCRIPTION
When the first window gets moved into the scratchpad, the second window ends up in a container by itself.

Break that window out of that container, so that the resulting tree for the current workspace has the exact same layout.