### PR TITLE
Fix and update flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1654876919,
-        "narHash": "sha256-tmG2glgRoFEyQojQ2/QKPbZY96l6VCoTcSxs/CPITYw=",
+        "lastModified": 1742975048,
+        "narHash": "sha256-23FFj0652nS2aFC1TnncmD53yDtgT/j90vZuzpWWacA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c4182b8047a24630c9ef7dddf09bfb40ec2149cd",
+        "rev": "99c7f9f160ebb27c18443dc6106e9fe06d139e8c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "swayhide - A window swallower for sway";
 
   inputs = {
-    nixpkgs.url = github:nixos/nixpkgs;
+    nixpkgs.url = "github:nixos/nixpkgs";
   };
 
   outputs = inputs:
@@ -21,7 +21,8 @@
           pname = "swayhide";
           version = "0.2.1";
           src = ./.;
-          cargoSha256 = "sha256-zsWixMdh5QHzjG8OdYVXQqjjuBDhTeqX7iAFeOyEOCk=";
+          useFetchCargoVendor = true;
+          cargoHash = "sha256-ng15mXfk3atT5/ELM47vpBneLZtzHdHDhCobrmlx3uQ=";
           nativeBuildInputs = with pkgs; [ installShellFiles ];
 
           postInstall = ''


### PR DESCRIPTION
The build stopped working because of an old cargo version in the pinned nixpkgs version.
I updated it and had to replace the deprecated `cargoSha256`.